### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,4 +1,6 @@
 name: Python Package using Conda
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/project_003/security/code-scanning/1](https://github.com/venkateshpabbati/project_003/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the current workflow since it only needs to read the repository contents to perform its tasks (e.g., checking out the code and running tests). No write permissions are required.

The `permissions` block will be added immediately after the `name` field in the workflow file to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
